### PR TITLE
chore: add krew release manifest template

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,3 +112,17 @@ jobs:
         with:
           name: kubectl-mapr-ticket-${{ matrix.goarch }}-${{ matrix.goos }}.tar.gz
           path: ./kubectl-mapr-ticket-${{ matrix.goarch }}-${{ matrix.goos }}.tar.gz
+
+  krew-release:
+    runs-on: ubuntu-latest
+
+    needs: build
+
+    if: contains(github.ref, 'tags')
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update new version in krew-index
+        uses: rajatjindal/krew-release-bot@v0.0.46

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,37 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: mapr-ticket
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/nobbs/kubectl-mapr-ticket
+  shortDescription: "Get information about deployed MapR tickets"
+  description: |
+    This plugin allows you to get information about MapR tickets deployed in the
+    cluster, including data parsed from the ticket itself, e.g. ticket expiry
+    date, user name, etc.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/nobbs/kubectl-mapr-ticket/releases/download/{{ .TagName }}/kubectl-mapr-ticket-amd64-darwin.tar.gz" .TagName }}
+    bin: kubectl-mapr-ticket
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/nobbs/kubectl-mapr-ticket/releases/download/{{ .TagName }}/kubectl-mapr-ticket-arm64-darwin.tar.gz" .TagName }}
+    bin: kubectl-mapr-ticket
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/nobbs/kubectl-mapr-ticket/releases/download/{{ .TagName }}/kubectl-mapr-ticket-amd64-linux.tar.gz" .TagName }}
+    bin: kubectl-mapr-ticket
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/nobbs/kubectl-mapr-ticket/releases/download/{{ .TagName }}/kubectl-mapr-ticket-arm64-linux.tar.gz" .TagName }}
+    bin: kubectl-mapr-ticket

--- a/README.md
+++ b/README.md
@@ -6,13 +6,12 @@ MapR tickets are used by the [MapR CSI driver](https://github.com/mapr/mapr-csi)
 
 ## Installation
 
-### From Source
+### Using `krew`
 
-To install from source, you will need to have [Go](https://golang.org/) installed on your system. Once you have Go installed, you can build the plugin as follows:
+The easiest way to install the plugin is using the [krew](https://krew.sigs.k8s.io/) plugin manager for `kubectl`. Once you have `krew` installed, you can install the plugin as follows:
 
 ```console
-$ git clone https://github.com/nobbs/kubectl-mapr-ticket.git
-$ cd kubectl-mapr-ticket && CGO_ENABLED=0 go build -buildvcs=true -o ./bin/kubectl-mapr-ticket ./cmd && mv ./bin/kubectl-mapr-ticket /usr/local/bin
+$ kubectl krew install mapr-ticket
 $ kubectl mapr-ticket --help
 ```
 
@@ -30,6 +29,16 @@ $ mv ./kubectl-mapr-ticket /usr/local/bin
 $ kubectl mapr-ticket --help
 ```
 <!-- x-release-please-end -->
+
+### From Source
+
+To install from source, you will need to have [Go](https://golang.org/) installed on your system. Once you have Go installed, you can build the plugin as follows:
+
+```console
+$ git clone https://github.com/nobbs/kubectl-mapr-ticket.git
+$ cd kubectl-mapr-ticket && CGO_ENABLED=0 go build -buildvcs=true -o ./bin/kubectl-mapr-ticket ./cmd && mv ./bin/kubectl-mapr-ticket /usr/local/bin
+$ kubectl mapr-ticket --help
+```
 
 ## Usage
 


### PR DESCRIPTION
Preparing for release as a [`krew`](http://krew.sigs.k8s.io) managed `kubectl` plugin.