### PR TITLE
feat: add `--expires-before <duration>` to `list`

### DIFF
--- a/cmd/cli/list.go
+++ b/cmd/cli/list.go
@@ -46,6 +46,10 @@ type ListOptions struct {
 	// in use by a persistent volume
 	FilterByInUse bool
 
+	// FilterExpiresBefore indicates whether to filter secrets to only those that
+	// expire before the specified duration from now
+	FilterExpiresBefore util.DurationValue
+
 	// ShowInUse indicates whether to show only secrets that are in use by a
 	// persistent volume
 	ShowInUse bool
@@ -98,6 +102,7 @@ some information about them.`,
 	cmd.Flags().Uint32Var(&o.FilterByMaprUID, "mapr-uid", 0, "Only show secrets with tickets for the specified UID")
 	cmd.Flags().Uint32Var(&o.FilterByMaprGID, "mapr-gid", 0, "Only show secrets with tickets for the specified GID")
 	cmd.Flags().BoolVarP(&o.FilterByInUse, "in-use", "I", false, "If true, only show secrets that are in use by a persistent volume")
+	cmd.Flags().Var(&o.FilterExpiresBefore, "expires-before", "Only show secrets with tickets that expire before the specified duration from now")
 	cmd.Flags().BoolVarP(&o.ShowInUse, "show-in-use", "i", false, "If true, add a column to the output indicating whether the secret is in use by a persistent volume")
 	cmd.MarkFlagsMutuallyExclusive("only-expired", "only-unexpired")
 
@@ -165,6 +170,10 @@ func (o *ListOptions) Run(cmd *cobra.Command, args []string) error {
 
 	if cmd.Flags().Changed("in-use") && o.FilterByInUse {
 		opts = append(opts, secret.WithFilterByInUse())
+	}
+
+	if cmd.Flags().Changed("expires-before") {
+		opts = append(opts, secret.WithFilterExpiresBefore(o.FilterExpiresBefore.Cast()))
 	}
 
 	if cmd.Flags().Changed("show-in-use") && o.ShowInUse {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
+	github.com/xhit/go-str2duration/v2 v2.1.0
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0
 	k8s.io/cli-runtime v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/ticket/ticket.go
+++ b/internal/ticket/ticket.go
@@ -83,3 +83,8 @@ func (ticket *MaprTicket) ExpirationTime() time.Time {
 func (ticket *MaprTicket) CreationTime() time.Time {
 	return time.Unix(int64(ticket.GetCreationTimeSec()), 0)
 }
+
+// ExpiresBefore returns true if the ticket expires before the given duration
+func (ticket *MaprTicket) ExpiresBefore(duration time.Duration) bool {
+	return ticket.ExpirationTime().Before(time.Now().Add(duration))
+}

--- a/internal/ticket/ticket_test.go
+++ b/internal/ticket/ticket_test.go
@@ -216,3 +216,45 @@ func TestIsExpired(t *testing.T) {
 		})
 	}
 }
+
+func TestExpiresBefore(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name     string
+		ticket   *ticket.MaprTicket
+		time     time.Duration
+		expected bool
+	}{
+		{
+			name: "ticket expires before the provided time",
+			ticket: func() *ticket.MaprTicket {
+				ticket := ticket.NewMaprTicket()
+				expiresInOneHour := time.Now().Add(1 * time.Hour).Unix()
+				ticket.TicketAndKey.ExpiryTime = ptr.To[uint64](uint64(expiresInOneHour))
+				return ticket
+			}(),
+			time:     2 * time.Hour,
+			expected: true,
+		},
+		{
+			name: "ticket does not expire before the provided time",
+			ticket: func() *ticket.MaprTicket {
+				ticket := ticket.NewMaprTicket()
+				expiresInTwoHours := time.Now().Add(2 * time.Hour).Unix()
+				ticket.TicketAndKey.ExpiryTime = ptr.To[uint64](uint64(expiresInTwoHours))
+				return ticket
+			}(),
+			time:     1 * time.Hour,
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.ticket.ExpiresBefore(test.time)
+
+			assert.Equal(test.expected, result)
+		})
+	}
+}

--- a/internal/util/cli.go
+++ b/internal/util/cli.go
@@ -1,0 +1,43 @@
+package util
+
+import (
+	"time"
+
+	"github.com/xhit/go-str2duration/v2"
+)
+
+// DurationValue is a wrapper around time.Duration that implements the
+// pflag.Value interface.
+//
+// Reason: the default time.Duration implementation of pflag.Value only supports
+// units up to hours. That's not really enough for us as we most likely want to
+// check for tickets that expire in a few days or even weeks. This wrapper uses
+// the go-str2duration library to additionally support days and weeks.
+type DurationValue time.Duration
+
+// NewDurationValue returns a new DurationValue with the specified time.Duration
+func NewDurationValue(val time.Duration) *DurationValue {
+	return (*DurationValue)(&val)
+}
+
+// Set implements the pflag.Value interface for DurationValue
+func (d *DurationValue) Set(s string) error {
+	v, err := str2duration.ParseDuration(s)
+	*d = DurationValue(v)
+	return err
+}
+
+// Type implements the pflag.Value interface for DurationValue
+func (d *DurationValue) Type() string {
+	return "duration"
+}
+
+// String implements the pflag.Value interface for DurationValue
+func (d *DurationValue) String() string {
+	return time.Duration(*d).String()
+}
+
+// Cast returns the underlying time.Duration value
+func (d *DurationValue) Cast() time.Duration {
+	return time.Duration(*d)
+}


### PR DESCRIPTION
This commit adds a new flag to the `list` command that provides another way to filter soon-to-expire tickets. The new flag is `--expires-before` and it accepts a duration string. Supported units are `s` (seconds), `m` (minutes), `h` (hours), `d` (days) and `w` (weeks). Combinations of units are also supported, e.g. `1h30m` is valid.

It's recommended to use the `--expires-before` flag with `--only-unexpired` to avoid listing already expired tickets.

Example usage:
```
kubectl mapr-ticket list --expires-before 1w --only-unexpired --all-namespaces
```

Closes: #16