### PR TITLE
feat: show number of PVs using a ticket on `list -i`

### DIFF
--- a/internal/secret/output.go
+++ b/internal/secret/output.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	listTableColumns = []metaV1.TableColumnDefinition{
+	tableColumns = []metaV1.TableColumnDefinition{
 		{
 			Name:        "Name",
 			Type:        "string",
@@ -31,7 +31,7 @@ var (
 			Priority:    0,
 		},
 		{
-			Name:        "User",
+			Name:        "Mapr User",
 			Type:        "string",
 			Description: "Name of the MapR user that the ticket is for",
 			Priority:    0,
@@ -81,6 +81,13 @@ var (
 			Priority:    0,
 		},
 	}
+
+	showInUseTableColumn = metaV1.TableColumnDefinition{
+		Name:        "#PVs",
+		Type:        "integer",
+		Description: "Number of persistent volumes using the ticket",
+		Priority:    0,
+	}
 )
 
 func Print(cmd *cobra.Command, items []ListItem) error {
@@ -123,7 +130,7 @@ func generateTable(items []ListItem) *metaV1.Table {
 	rows := generateRows(items)
 
 	return &metaV1.Table{
-		ColumnDefinitions: listTableColumns,
+		ColumnDefinitions: tableColumns,
 		Rows:              rows,
 	}
 }
@@ -168,24 +175,19 @@ func generateRow(item *ListItem) *metaV1.TableRow {
 // enrichTableWithInUse enriches the table with a column indicating whether the
 // ticket is in use by a persistent volume or not
 func enrichTableWithInUse(table *metaV1.Table, items []ListItem) {
-	numColumns := len(listTableColumns)
+	insertPos := len(tableColumns) - 1
 
 	table.ColumnDefinitions = append(
-		table.ColumnDefinitions[:numColumns-1],
-		metaV1.TableColumnDefinition{
-			Name:        "In Use",
-			Type:        "boolean",
-			Description: "Whether the ticket is in use by a persistent volume or not",
-			Priority:    0,
-		},
-		table.ColumnDefinitions[numColumns-1],
+		table.ColumnDefinitions[:insertPos],
+		showInUseTableColumn,
+		table.ColumnDefinitions[insertPos],
 	)
 
 	for i := range table.Rows {
 		table.Rows[i].Cells = append(
-			table.Rows[i].Cells[:numColumns-1],
+			table.Rows[i].Cells[:insertPos],
 			items[i].InUse,
-			table.Rows[i].Cells[numColumns-1],
+			table.Rows[i].Cells[insertPos],
 		)
 	}
 }

--- a/internal/secret/secret.go
+++ b/internal/secret/secret.go
@@ -14,7 +14,7 @@ import (
 type ListItem struct {
 	Secret *coreV1.Secret     `json:"originalSecret"`
 	Ticket *ticket.MaprTicket `json:"parsedTicket"`
-	InUse  bool               `json:"inUse"`
+	InUse  uint32             `json:"inUse"`
 }
 
 type Lister struct {
@@ -304,8 +304,7 @@ func (l *Lister) enrichItemsWithInUseCondition(items []ListItem) ([]ListItem, er
 	for i := range items {
 		for _, pv := range maprVolumes {
 			if volume.UsesTicket(&pv, items[i].Secret.Name, items[i].Secret.Namespace) {
-				items[i].InUse = true
-				break
+				items[i].InUse++
 			}
 		}
 	}
@@ -318,7 +317,7 @@ func filterItemsToOnlyInUse(items []ListItem) []ListItem {
 	var filtered []ListItem
 
 	for _, item := range items {
-		if item.InUse {
+		if item.InUse > 0 {
 			filtered = append(filtered, item)
 		}
 	}


### PR DESCRIPTION
This commit changes the `--show-in-use` flag of the `list` command to show the number of persistent volumes using a ticket instead of a boolean value - this is more useful information, as it allows users to quickly see which tickets are used a lot and which are not.

Closes: #20