### PR TITLE
feat: add sort option to `list` command

### DIFF
--- a/internal/secret/sort.go
+++ b/internal/secret/sort.go
@@ -1,0 +1,106 @@
+package secret
+
+import (
+	"fmt"
+	"sort"
+)
+
+type SortOptions string
+
+const (
+	SortByName              SortOptions = "name"
+	SortByNamespace         SortOptions = "namespace"
+	SortByMaprCluster       SortOptions = "maprCluster"
+	SortByMaprUser          SortOptions = "maprUser"
+	SortByCreationTimestamp SortOptions = "creationTimestamp"
+	SortByExpiryTime        SortOptions = "expiryTime"
+)
+
+// ValidateSortOptions validates the specified sort options
+func ValidateSortOptions(sortOptions []string) error {
+	for _, sortOption := range sortOptions {
+		switch sortOption {
+		case string(SortByName):
+		case string(SortByNamespace):
+		case string(SortByMaprCluster):
+		case string(SortByMaprUser):
+		case string(SortByCreationTimestamp):
+		case string(SortByExpiryTime):
+		default:
+			return fmt.Errorf("invalid sort option: %s. Must be one of: name|namespace|maprCluster|maprUser|creationTimestamp|expiryTime", sortOption)
+		}
+	}
+
+	return nil
+}
+
+// sortByName sorts the items by secret name
+func sortByName(items []ListItem) {
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Secret.Name < items[j].Secret.Name
+	})
+}
+
+// sortByNamespace sorts the items by secret namespace
+func sortByNamespace(items []ListItem) {
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Secret.Namespace < items[j].Secret.Namespace
+	})
+}
+
+// sortByMaprCluster sorts the items by MapR cluster that the ticket is for
+func sortByMaprCluster(items []ListItem) {
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Ticket.Cluster < items[j].Ticket.Cluster
+	})
+}
+
+// sortByMaprUser sorts the items by MapR user that the ticket is for
+func sortByMaprUser(items []ListItem) {
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Ticket.UserCreds.GetUserName() < items[j].Ticket.UserCreds.GetUserName()
+	})
+}
+
+// sortByCreationTimestamp sorts the items by creation timestamp of the ticket
+func sortByCreationTimestamp(items []ListItem) {
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Ticket.CreationTime().Before(items[j].Ticket.CreationTime())
+	})
+}
+
+// sortByExpiryTime sorts the items by expiry time of the ticket
+func sortByExpiryTime(items []ListItem) {
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Ticket.ExpirationTime().Before(items[j].Ticket.ExpirationTime())
+	})
+}
+
+// Sort sorts the items by the specified sort options, in reverse order of the
+// order in which they are specified. This makes for a more natural sort result
+// when using multiple sort options.
+func Sort(items []ListItem, sortOptions []SortOptions) {
+	// reverse the order of the sort options
+	order := make([]SortOptions, len(sortOptions))
+	for i, j := 0, len(sortOptions)-1; i < len(sortOptions); i, j = i+1, j-1 {
+		order[i] = sortOptions[j]
+	}
+
+	// sort the items by each sort option
+	for _, sortOption := range order {
+		switch sortOption {
+		case SortByName:
+			sortByName(items)
+		case SortByNamespace:
+			sortByNamespace(items)
+		case SortByMaprCluster:
+			sortByMaprCluster(items)
+		case SortByMaprUser:
+			sortByMaprUser(items)
+		case SortByCreationTimestamp:
+			sortByCreationTimestamp(items)
+		case SortByExpiryTime:
+			sortByExpiryTime(items)
+		}
+	}
+}

--- a/internal/secret/sort_test.go
+++ b/internal/secret/sort_test.go
@@ -1,0 +1,1 @@
+package secret_test


### PR DESCRIPTION
This commit adds a `--sort-by` option to the `list` command. This option allows the user to specify the fields by which to sort the list of tickets. Multiple fields can be specified, separated by commas. The sort order is the reverse of the order in which the fields are specified. This makes for a more natural sort result when using multiple sort options, e.g. `--sort-by namespace,name` will sort by name first, then by namespace - this will result in a list that is sorted by namespace, then by name.

The following fields can be specified:

* `name`
* `namespace`
* `maprCluster`
* `maprUser`
* `creationTimestamp`
* `expiryTime`

The default sort order is `namespace,name`.

Closes: #19 