### PR TITLE
fix: handle duration overflow (> 292 years)

### DIFF
--- a/internal/util/date.go
+++ b/internal/util/date.go
@@ -1,47 +1,93 @@
 package util
 
 import (
+	"math"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/duration"
 )
 
+// HumanDurationComparedToNow returns a human readable string representing the
+// duration between the given time and now. Always returns a positive duration.
 func HumanDurationComparedToNow(t time.Time) string {
-	difference := time.Since(t)
+	d := time.Since(t)
 
-	if difference < 0 {
-		return HumanDuration(-difference)
+	// edge case: if the difference is the maximum absolute value of an int64,
+	// then we hit the max possible duration in any direction. In this case,
+	// we'll just return "inf" as the duration.
+	if d.Abs() == math.MaxInt64 {
+		return "inf"
 	}
 
-	return HumanDuration(difference)
+	// if the difference is negative, then we'll just return the human readable string
+	// for the positive difference, but with a negative sign in front of it.
+	if d < 0 {
+		return HumanDuration(-d)
+	}
+
+	return HumanDuration(d)
 }
 
+// ShortHumanDurationComparedToNow returns a short human readable string
+// representing the duration between the given time and now. Always returns a
+// positive duration.
 func ShortHumanDurationComparedToNow(t time.Time) string {
-	difference := time.Since(t)
+	d := time.Since(t)
 
-	if difference < 0 {
-		return ShortHumanDuration(-difference)
+	// edge case: if the difference is the maximum absolute value of an int64,
+	// then we hit the max possible duration in any direction. In this case,
+	// we'll just return "inf" as the duration.
+	if d.Abs() == math.MaxInt64 {
+		return "inf"
 	}
 
-	return ShortHumanDuration(difference)
+	// if the difference is negative, then we'll just return the human readable string
+	// for the positive difference, but with a negative sign in front of it.
+	if d < 0 {
+		return ShortHumanDuration(-d)
+	}
+
+	return ShortHumanDuration(d)
 }
 
+// HumanDurationUntilNow returns a human readable string representing the
+// duration between the given time and now.
 func HumanDurationUntilNow(t time.Time) string {
-	difference := time.Since(t)
+	d := time.Since(t)
 
-	return HumanDuration(difference)
+	// edge case: if the difference is the maximum absolute value of an int64,
+	// then we hit the max possible duration in any direction. In this case,
+	// we'll just return "inf" as the duration.
+	if d.Abs() == math.MaxInt64 {
+		return "inf"
+	}
+
+	return HumanDuration(d)
 }
 
+// ShortHumanDurationUntilNow returns a short human readable string
+// representing the duration between the given time and now.
 func ShortHumanDurationUntilNow(t time.Time) string {
-	difference := time.Since(t)
+	d := time.Since(t)
 
-	return ShortHumanDuration(difference)
+	// edge case: if the difference is the maximum absolute value of an int64,
+	// then we hit the max possible duration in any direction. In this case,
+	// we'll just return "inf" as the duration.
+	if d.Abs() == math.MaxInt64 {
+		return "inf"
+	}
+
+	return ShortHumanDuration(d)
 }
 
-func HumanDuration(time time.Duration) string {
-	return duration.HumanDuration(time)
+// HumanDuration returns a human readable string representing the given
+// duration.
+func HumanDuration(d time.Duration) string {
+	return duration.HumanDuration(d)
 }
 
-func ShortHumanDuration(time time.Duration) string {
-	return duration.ShortHumanDuration(time)
+// ShortHumanDuration returns a short human readable string representing the
+// given duration.
+func ShortHumanDuration(d time.Duration) string {
+	return duration.ShortHumanDuration(d)
 }


### PR DESCRIPTION
This commit fixes a bug where a duration that is greater than 292 years would return a `<invalid>` string instead of a human readable string. This is because the `time.Duration` type is an `int64` and uses nanoseconds as the unit of time. The maximum value of an `int64` is `9223372036854775807` which is roughly 292 years. If the duration is greater than that, then the `time.Duration` type be capped at the maximum value and the `HumanDuration` function will return `<invalid>`.

This commit fixes this by checking if the duration is the maximum value of an `int64` and if so, returning `inf` as the duration.

Closes: #23