### PR TITLE
fix: add option to sort secrets by number of PVCs using them

### DIFF
--- a/cmd/cli/list.go
+++ b/cmd/cli/list.go
@@ -41,7 +41,7 @@ const (
 
 var (
 	listValidOutputFormats = []string{"table", "wide", "json", "yaml"}
-	listValidSortByFields  = []string{"name", "namespace", "maprCluster", "maprUser", "creationTimestamp", "expiryTime"}
+	listValidSortByFields  = []string{"name", "namespace", "maprCluster", "maprUser", "creationTimestamp", "expiryTime", "numPVC"}
 )
 
 type ListOptions struct {
@@ -135,9 +135,9 @@ func newListCmd(rootOpts *rootCmdOptions) *cobra.Command {
 	cmd.SetErr(o.IOStreams.ErrOut)
 
 	// add flags
-	cmd.Flags().StringVarP(&o.OutputFormat, "output", "o", "table", "Output format. One of: table|wide|json|yaml")
+	cmd.Flags().StringVarP(&o.OutputFormat, "output", "o", "table", fmt.Sprintf("Output format. One of (%s)", util.StringSliceToFlagOptions(listValidOutputFormats)))
 	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", false, "If true, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
-	cmd.Flags().StringSliceVar(&o.SortBy, "sort-by", nil, "Sort list by the specified fields. Multiple fields can be specified, separated by commas. Valid fields are: name|namespace|maprCluster|maprUser|creationTimestamp|expiryTime")
+	cmd.Flags().StringSliceVar(&o.SortBy, "sort-by", nil, fmt.Sprintf("Sort list of secrets by the specified fields. One of (%s)", util.StringSliceToFlagOptions(listValidSortByFields)))
 	cmd.Flags().BoolVarP(&o.FilterOnlyExpired, "only-expired", "E", false, "If true, only show secrets with tickets that have expired")
 	cmd.Flags().BoolVarP(&o.FilterOnlyUnexpired, "only-unexpired", "U", false, "If true, only show secrets with tickets that have not expired")
 	cmd.Flags().StringVarP(&o.FilterByMaprCluster, "mapr-cluster", "c", "", "Only show secrets with tickets for the specified MapR cluster")

--- a/cmd/cli/usedby.go
+++ b/cmd/cli/usedby.go
@@ -95,7 +95,7 @@ func newUsedByCmd(rootOpts *rootCmdOptions) *cobra.Command {
 	cmd.SetErr(o.IOStreams.ErrOut)
 
 	// add flags
-	cmd.Flags().StringVarP(&o.OutputFormat, "output", "o", "table", "Output format. One of: table|wide")
+	cmd.Flags().StringVarP(&o.OutputFormat, "output", "o", "table", fmt.Sprintf("Output format. One of (%s)", util.StringSliceToFlagOptions(usedByValidOutputFormats)))
 	cmd.Flags().BoolVarP(&o.AllSecrets, "all", "a", false, "List persistent volumes for all MapR ticket secrets in the current namespace")
 
 	// register completions for flags

--- a/internal/secret/output.go
+++ b/internal/secret/output.go
@@ -186,7 +186,7 @@ func enrichTableWithInUse(table *metaV1.Table, items []ListItem) {
 	for i := range table.Rows {
 		table.Rows[i].Cells = append(
 			table.Rows[i].Cells[:insertPos],
-			items[i].InUse,
+			items[i].NumPVC,
 			table.Rows[i].Cells[insertPos],
 		)
 	}

--- a/internal/secret/secret.go
+++ b/internal/secret/secret.go
@@ -14,7 +14,7 @@ import (
 type ListItem struct {
 	Secret *coreV1.Secret     `json:"originalSecret"`
 	Ticket *ticket.MaprTicket `json:"parsedTicket"`
-	InUse  uint32             `json:"inUse"`
+	NumPVC uint32             `json:"numPVC"`
 }
 
 type Lister struct {
@@ -322,7 +322,7 @@ func (l *Lister) enrichItemsWithInUseCondition(items []ListItem) ([]ListItem, er
 	for i := range items {
 		for _, pv := range maprVolumes {
 			if volume.UsesTicket(&pv, items[i].Secret.Name, items[i].Secret.Namespace) {
-				items[i].InUse++
+				items[i].NumPVC++
 			}
 		}
 	}
@@ -335,7 +335,7 @@ func filterItemsToOnlyInUse(items []ListItem) []ListItem {
 	var filtered []ListItem
 
 	for _, item := range items {
-		if item.InUse > 0 {
+		if item.NumPVC > 0 {
 			filtered = append(filtered, item)
 		}
 	}

--- a/internal/secret/sort.go
+++ b/internal/secret/sort.go
@@ -14,6 +14,7 @@ const (
 	SortByMaprUser          SortOptions = "maprUser"
 	SortByCreationTimestamp SortOptions = "creationTimestamp"
 	SortByExpiryTime        SortOptions = "expiryTime"
+	SortByNumPVC            SortOptions = "numPVC"
 )
 
 // ValidateSortOptions validates the specified sort options
@@ -26,6 +27,7 @@ func ValidateSortOptions(sortOptions []string) error {
 		case string(SortByMaprUser):
 		case string(SortByCreationTimestamp):
 		case string(SortByExpiryTime):
+		case string(SortByNumPVC):
 		default:
 			return fmt.Errorf("invalid sort option: %s. Must be one of: name|namespace|maprCluster|maprUser|creationTimestamp|expiryTime", sortOption)
 		}
@@ -76,6 +78,14 @@ func sortByExpiryTime(items []ListItem) {
 	})
 }
 
+// sortByNumPVC sorts the items by the number of persistent volumes that are
+// using the secret
+func sortByNumPVC(items []ListItem) {
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].NumPVC < items[j].NumPVC
+	})
+}
+
 // Sort sorts the items by the specified sort options, in reverse order of the
 // order in which they are specified. This makes for a more natural sort result
 // when using multiple sort options.
@@ -101,6 +111,8 @@ func Sort(items []ListItem, sortOptions []SortOptions) {
 			sortByCreationTimestamp(items)
 		case SortByExpiryTime:
 			sortByExpiryTime(items)
+		case SortByNumPVC:
+			sortByNumPVC(items)
 		}
 	}
 }

--- a/internal/util/cli.go
+++ b/internal/util/cli.go
@@ -95,3 +95,7 @@ func (s stringNormalizer) indent() stringNormalizer {
 	s.string = strings.Join(lines, "\n")
 	return s
 }
+
+func StringSliceToFlagOptions(slice []string) string {
+	return strings.Join(slice, ", ")
+}


### PR DESCRIPTION
This commit adds a new `--sort-by numPVC` option to the `list` command that allows the user to sort the secrets by the number of persistent. Requires the `--show-in-use` option to be specified to collect the number of PVCs using each secret.