### PR TITLE
fix: ticket status not properly parsed in `claim` command

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -7,9 +7,11 @@ tasks:
   build:
     desc: Build the binary
     cmds:
-      - go build -buildvcs=true -o {{.BIN}} ./cmd/
+      - go build -buildvcs=true -o bin/kubectl-mapr_ticket ./
     sources:
       - ./**/*.go
+    generates:
+      - bin/kubectl-mapr_ticket
 
   test:
     desc: Run tests

--- a/cmd/claim/claim.go
+++ b/cmd/claim/claim.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nobbs/kubectl-mapr-ticket/cmd/common"
 	"github.com/nobbs/kubectl-mapr-ticket/pkg/claim"
+	"github.com/nobbs/kubectl-mapr-ticket/pkg/secret"
 	"github.com/nobbs/kubectl-mapr-ticket/pkg/util"
 )
 
@@ -108,8 +109,23 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// create secret lister
+	secretLister := secret.NewLister(
+		client,
+		util.NamespaceAll,
+	)
+
+	// create list options and pass them to the lister
+	opts := []claim.ListerOption{
+		claim.WithSecretLister(secretLister),
+	}
+
 	// create lister
-	lister := claim.NewLister(client, *o.KubernetesConfigFlags.Namespace)
+	lister := claim.NewLister(
+		client,
+		*o.KubernetesConfigFlags.Namespace,
+		opts...,
+	)
 
 	// run lister
 	volumeClaims, err := lister.List()

--- a/pkg/claim/claim.go
+++ b/pkg/claim/claim.go
@@ -5,6 +5,7 @@ import (
 
 	apiClaim "github.com/nobbs/kubectl-mapr-ticket/pkg/api/claim"
 	apiSecret "github.com/nobbs/kubectl-mapr-ticket/pkg/api/secret"
+	apiVolume "github.com/nobbs/kubectl-mapr-ticket/pkg/api/volume"
 	"github.com/nobbs/kubectl-mapr-ticket/pkg/volume"
 
 	coreV1 "k8s.io/api/core/v1"
@@ -158,9 +159,11 @@ func (l *Lister) collectTickets() *Lister {
 
 	// lookup the ticket for each volume claim
 	lookupTicket := func(volumeClaim *apiClaim.VolumeClaim) *apiSecret.TicketSecret {
+		volume := apiVolume.NewVolume(volumeClaim.Volume)
+
 		for _, ticket := range tickets {
-			if ticket.Secret.Namespace == volumeClaim.Claim.Namespace &&
-				ticket.Secret.Name == volumeClaim.Claim.Name {
+			if ticket.Secret.Namespace == volume.SecretNamespace() &&
+				ticket.Secret.Name == volume.SecretName() {
 				return &ticket
 			}
 		}


### PR DESCRIPTION
This commit fixes a bug where the ticket status was not properly parsed in the `claim` command. This was due to the fact that the secrets were not yet grabbed from the cluster.